### PR TITLE
fix: prepare v1.2.3 patch release

### DIFF
--- a/.github/workflows/podcheck-test.yml
+++ b/.github/workflows/podcheck-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install podman
         run: |
           sudo apt-get update
-          sudo apt-get install -y podman
+          sudo apt-get install -y jq podman
 
       - name: Test help command
         run: |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ All dockcheck v0.7.1 notification services are now supported with enhanced funct
 ___
 ## Changelog
 
+- **v1.2.3**: 🐛 **Bug Fixes**
+    - **Fixed**: Keep comma-separated container filters working through the whole run.
+    - **Fixed**: Export Prometheus totals and check duration while keeping the existing dashboard metrics.
+    - **Fixed**: Return cleanly from sourced webhook notification templates.
+    - **Fixed**: Show self-update change notes reliably.
 - **v1.2.2**: 🐛 **Bug Fixes**
     - **Fixed**: Fix compose container recreation after image pull.
 - **v1.2.1**: 🐛 **Bug Fixes**

--- a/addons/prometheus/README.md
+++ b/addons/prometheus/README.md
@@ -7,7 +7,7 @@ A simple cron job can be configured to export these metrics on a regular interva
 0 1 * * * /root/podcheck.sh -n -c /var/lib/node_exporter/textfile_collector
 ```
 
-The following metrics are exported to prometheus
+The following metrics are exported to Prometheus. The `podcheck_images_*` metrics are kept for dashboard compatibility, and the `podcheck_*` metrics expose the same counts plus run duration.
 
 ```
 # HELP podcheck_images_analyzed Podman images that have been analyzed
@@ -25,6 +25,24 @@ podcheck_images_error 1
 # HELP podcheck_images_analyze_timestamp_seconds Last podcheck run time
 # TYPE podcheck_images_analyze_timestamp_seconds gauge
 podcheck_images_analyze_timestamp_seconds 1737924029
+# HELP podcheck_no_updates Number of containers already on latest image.
+# TYPE podcheck_no_updates gauge
+podcheck_no_updates 14
+# HELP podcheck_updates Number of containers with updates available.
+# TYPE podcheck_updates gauge
+podcheck_updates 7
+# HELP podcheck_errors Number of containers with errors during update check.
+# TYPE podcheck_errors gauge
+podcheck_errors 1
+# HELP podcheck_total Total number of containers checked.
+# TYPE podcheck_total gauge
+podcheck_total 22
+# HELP podcheck_check_duration Duration in seconds for the update check.
+# TYPE podcheck_check_duration gauge
+podcheck_check_duration 12
+# HELP podcheck_last_check_timestamp Epoch timestamp of the last update check.
+# TYPE podcheck_last_check_timestamp gauge
+podcheck_last_check_timestamp 1737924029
 ```
 
 Once those metrics are exported they can be used to define alarms as shown below

--- a/addons/prometheus/prometheus_collector.sh
+++ b/addons/prometheus/prometheus_collector.sh
@@ -28,13 +28,35 @@ prometheus_exporter() {
   local no_updates="$1"
   local updates="$2"
   local errors="$3"
-  local total="$4"
-  local check_duration="$5"
+  local total="${4:-$((no_updates + updates + errors))}"
+  local check_duration="${5:-0}"
   local collector_dir="${CollectorTextFileDirectory:-/tmp}"
+  local metrics_file="${collector_dir}/podcheck.prom"
+  local tmp_file="${metrics_file}.$$"
   local last_check_timestamp
   last_check_timestamp=$(date +%s)
 
   {
+    echo "# HELP podcheck_images_analyzed Podman images that have been analyzed."
+    echo "# TYPE podcheck_images_analyzed gauge"
+    echo "podcheck_images_analyzed $total"
+
+    echo "# HELP podcheck_images_outdated Podman images that are outdated."
+    echo "# TYPE podcheck_images_outdated gauge"
+    echo "podcheck_images_outdated $updates"
+
+    echo "# HELP podcheck_images_latest Podman images that are on the latest image."
+    echo "# TYPE podcheck_images_latest gauge"
+    echo "podcheck_images_latest $no_updates"
+
+    echo "# HELP podcheck_images_error Podman images with analysis errors."
+    echo "# TYPE podcheck_images_error gauge"
+    echo "podcheck_images_error $errors"
+
+    echo "# HELP podcheck_images_analyze_timestamp_seconds Last podcheck run time."
+    echo "# TYPE podcheck_images_analyze_timestamp_seconds gauge"
+    echo "podcheck_images_analyze_timestamp_seconds $last_check_timestamp"
+
     echo "# HELP podcheck_no_updates Number of containers already on latest image."
     echo "# TYPE podcheck_no_updates gauge"
     echo "podcheck_no_updates $no_updates"
@@ -58,5 +80,5 @@ prometheus_exporter() {
     echo "# HELP podcheck_last_check_timestamp Epoch timestamp of the last update check."
     echo "# TYPE podcheck_last_check_timestamp gauge"
     echo "podcheck_last_check_timestamp $last_check_timestamp"
-  } > "$collector_dir/podcheck.prom"
+  } > "$tmp_file" && mv "$tmp_file" "$metrics_file"
 }

--- a/notify_templates/notify_HA.sh
+++ b/notify_templates/notify_HA.sh
@@ -7,7 +7,12 @@
 # Check if required variables are set
 if [[ -z "${HA_URL:-}" ]] || [[ -z "${HA_TOKEN:-}" ]]; then
     echo "Error: HA_URL and HA_TOKEN must be set in podcheck.config"
-    exit 1
+    return 1
+fi
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required for Home Assistant notifications"
+    return 1
 fi
 
 # Default webhook ID if not specified
@@ -17,17 +22,18 @@ HA_WEBHOOK_ID="${HA_WEBHOOK_ID:-automation}"
 WEBHOOK_URL="${HA_URL}/api/webhook/${HA_WEBHOOK_ID}"
 
 # Prepare the JSON payload
-JSON_PAYLOAD=$(cat <<EOF
-{
-    "title": "${NOTIFICATION_TITLE}",
-    "message": "${NOTIFICATION_MESSAGE}",
-    "data": {
-        "source": "podcheck",
-        "timestamp": "$(date -Iseconds)"
-    }
-}
-EOF
-)
+JSON_PAYLOAD=$(jq -n \
+    --arg title "${NOTIFICATION_TITLE:-Podcheck Notification}" \
+    --arg message "${NOTIFICATION_MESSAGE:-}" \
+    --arg timestamp "$(date -Iseconds)" \
+    '{
+        title: $title,
+        message: $message,
+        data: {
+            source: "podcheck",
+            timestamp: $timestamp
+        }
+    }')
 
 # Send the notification
 if curl -s -X POST \
@@ -36,7 +42,8 @@ if curl -s -X POST \
     -d "${JSON_PAYLOAD}" \
     "${WEBHOOK_URL}" > /dev/null; then
     echo "Home Assistant notification sent successfully"
+    return 0
 else
     echo "Failed to send Home Assistant notification"
-    exit 1
+    return 1
 fi

--- a/notify_templates/notify_discord.sh
+++ b/notify_templates/notify_discord.sh
@@ -8,29 +8,30 @@ if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
   return 1
 fi
 
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required for Discord notifications"
+  return 1
+fi
+
 # Prepare the Discord message
 if [[ -n "${NOTIFICATION_MESSAGE:-}" ]]; then
-  # Format message for Discord - escape quotes and newlines
-  discord_content="${NOTIFICATION_MESSAGE}"
-  discord_content="${discord_content//\"/\\\"}"
-  discord_content="${discord_content//$'\n'/\\n}"
-  
   # Create Discord webhook payload
-  discord_payload=$(cat <<EOF
-{
-  "content": "${discord_content}",
-  "username": "Podcheck",
-  "embeds": [
-    {
-      "title": "${NOTIFICATION_TITLE:-Podcheck Notification}",
-      "description": "${discord_content}",
-      "color": 3447003,
-      "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
-    }
-  ]
-}
-EOF
-)
+  discord_payload=$(jq -n \
+    --arg content "${NOTIFICATION_MESSAGE}" \
+    --arg title "${NOTIFICATION_TITLE:-Podcheck Notification}" \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+    '{
+      content: $content,
+      username: "Podcheck",
+      embeds: [
+        {
+          title: $title,
+          description: $content,
+          color: 3447003,
+          timestamp: $timestamp
+        }
+      ]
+    }')
 
   # Send to Discord
   if curl -H "Content-Type: application/json" \

--- a/notify_templates/notify_slack.sh
+++ b/notify_templates/notify_slack.sh
@@ -7,14 +7,16 @@
 # Check if required variables are set
 if [[ -z "${SLACK_WEBHOOK_URL:-}" ]]; then
     echo "Error: SLACK_WEBHOOK_URL must be set in podcheck.config"
-    exit 1
+    return 1
+fi
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required for Slack notifications"
+    return 1
 fi
 
 # Optional Slack channel (if not using webhook default)
-SLACK_CHANNEL_ARG=""
-if [[ -n "${SLACK_CHANNEL:-}" ]]; then
-    SLACK_CHANNEL_ARG=", \"channel\": \"${SLACK_CHANNEL}\""
-fi
+SLACK_CHANNEL="${SLACK_CHANNEL:-}"
 
 # Optional username override
 SLACK_USERNAME="${SLACK_USERNAME:-podcheck}"
@@ -23,22 +25,26 @@ SLACK_USERNAME="${SLACK_USERNAME:-podcheck}"
 SLACK_ICON="${SLACK_ICON:-:whale:}"
 
 # Prepare the JSON payload
-JSON_PAYLOAD=$(cat <<EOF
-{
-    "username": "${SLACK_USERNAME}",
-    "icon_emoji": "${SLACK_ICON}",
-    "text": "${NOTIFICATION_TITLE}",
-    "attachments": [
-        {
-            "color": "warning",
-            "text": "${NOTIFICATION_MESSAGE}",
-            "footer": "podcheck",
-            "ts": $(date +%s)
-        }
-    ]${SLACK_CHANNEL_ARG}
-}
-EOF
-)
+JSON_PAYLOAD=$(jq -n \
+    --arg username "$SLACK_USERNAME" \
+    --arg icon "$SLACK_ICON" \
+    --arg title "${NOTIFICATION_TITLE:-Podcheck Notification}" \
+    --arg message "${NOTIFICATION_MESSAGE:-}" \
+    --arg channel "$SLACK_CHANNEL" \
+    --argjson ts "$(date +%s)" \
+    '{
+        username: $username,
+        icon_emoji: $icon,
+        text: $title,
+        attachments: [
+            {
+                color: "warning",
+                text: $message,
+                footer: "podcheck",
+                ts: $ts
+            }
+        ]
+    } + (if $channel == "" then {} else {channel: $channel} end)')
 
 # Send the notification
 if curl -s -X POST \
@@ -46,7 +52,8 @@ if curl -s -X POST \
     -d "${JSON_PAYLOAD}" \
     "${SLACK_WEBHOOK_URL}" > /dev/null; then
     echo "Slack notification sent successfully"
+    return 0
 else
     echo "Failed to send Slack notification"
-    exit 1
+    return 1
 fi

--- a/notify_templates/notify_telegram.sh
+++ b/notify_templates/notify_telegram.sh
@@ -9,25 +9,26 @@ if [[ -z "${TELEGRAM_TOKEN:-}" ]] || [[ -z "${TELEGRAM_CHAT_ID:-}" ]]; then
   return 1
 fi
 
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required for Telegram notifications"
+  return 1
+fi
+
 # Prepare the Telegram message
 if [[ -n "${NOTIFICATION_MESSAGE:-}" ]]; then
-  # Escape special characters for JSON
-  telegram_message="${NOTIFICATION_MESSAGE}"
-  telegram_message="${telegram_message//\"/\\\"}"
-  telegram_message="${telegram_message//$'\n'/\\n}"
-  
   # Build Telegram URL
   telegram_url="https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage"
-  
+
   # Create payload
-  telegram_data="{\"chat_id\":\"${TELEGRAM_CHAT_ID}\",\"text\":\"${telegram_message}\""
-  
-  # Add topic ID if specified
-  if [[ -n "${TELEGRAM_TOPIC_ID:-}" && "${TELEGRAM_TOPIC_ID}" != "0" ]]; then
-    telegram_data="${telegram_data},\"message_thread_id\":\"${TELEGRAM_TOPIC_ID}\""
-  fi
-  
-  telegram_data="${telegram_data},\"disable_notification\": false}"
+  telegram_data=$(jq -n \
+    --arg chat_id "${TELEGRAM_CHAT_ID}" \
+    --arg text "${NOTIFICATION_MESSAGE}" \
+    --arg topic "${TELEGRAM_TOPIC_ID:-}" \
+    '{
+      chat_id: $chat_id,
+      text: $text,
+      disable_notification: false
+    } + (if $topic == "" or $topic == "0" then {} else {message_thread_id: $topic} end)')
   
   # Send to Telegram
   if curl -s -o /dev/null --fail -X POST \

--- a/podcheck.sh
+++ b/podcheck.sh
@@ -3,14 +3,14 @@ set -euo pipefail
 shopt -s nullglob
 shopt -s failglob
 
-VERSION="v1.2.2"
+VERSION="v1.2.3"
 
 # Variables for self-updating
 ScriptArgs=( "$@" )
 ScriptPath="$(readlink -f "$0")"
 ScriptWorkDir="$(dirname "$ScriptPath")"
 
-# ChangeNotes: Fix self_update function ordering, improve CI workflows, add release automation
+# ChangeNotes: Fix filters, Prometheus metrics, webhook returns, and self-update notes
 Github="https://github.com/sudo-kraken/podcheck"
 RawUrl="https://raw.githubusercontent.com/sudo-kraken/podcheck/main/podcheck.sh"
 

--- a/podcheck.sh
+++ b/podcheck.sh
@@ -188,12 +188,12 @@ shift "$((OPTIND-1))"
 
 # Set $1 to a variable for name filtering later, rewriting if multiple
 SearchName="${1:-}"
-if [[ ! -z "$SearchName" ]]; then
+if [[ -n "$SearchName" ]]; then
   SearchName="^(${SearchName//,/|})$"
 fi
 
 # Check if there's a new release of the script
-LatestSnippet="$(curl ${CurlArgs} -r 0-200 "$RawUrl" || printf "undefined")"
+LatestSnippet="$(curl ${CurlArgs} -r 0-1024 "$RawUrl" || printf "undefined")"
 LatestRelease="$(echo "${LatestSnippet}" | sed -n "/VERSION/s/VERSION=//p" | tr -d '"')"
 LatestChanges="$(echo "${LatestSnippet}" | sed -n "/ChangeNotes/s/# ChangeNotes: //p")"
 
@@ -234,9 +234,6 @@ exec_if_exists() {
 exec_if_exists_or_fail() {
   [[ $(type -t $1) == function ]] && "$@"
 }
-
-# Now get the search name from the first remaining positional parameter
-SearchName="${1:-}"
 
 choosecontainers() {
   while [[ -z "${ChoiceClean:-}" ]]; do
@@ -501,14 +498,6 @@ if [[ -n ${Excludes[*]:-} ]]; then
   printf "\n"
 fi
 
-
-
-if [[ -n "${Excludes[*]}" ]]; then
-  printf "\n%bExcluding these names:%b\n" "$c_blue" "$c_reset"
-  printf "%s\n" "${Excludes[@]}"
-  printf "\n"
-fi
-
 ContCount=$(podman ps $Stopped --filter "name=$SearchName" --format '{{.Names}}' | wc -l)
 RegCheckQue=0
 start_time=$(date +%s)
@@ -607,7 +596,10 @@ unset IFS
 
 # Run the prometheus exporter function
 if [[ -n "${CollectorTextFileDirectory:-}" ]]; then
-  exec_if_exists_or_fail prometheus_exporter ${#NoUpdates[@]} ${#GotUpdates[@]} ${#GotErrors[@]} || printf "%s\n" "Could not source prometheus exporter function."
+  check_duration=$(( $(date +%s) - start_time ))
+  exec_if_exists_or_fail prometheus_exporter \
+    "${#NoUpdates[@]}" "${#GotUpdates[@]}" "${#GotErrors[@]}" "$ContCount" "$check_duration" \
+    || printf "%s\n" "Could not source prometheus exporter function."
 fi
 
 # Define how many updates are available

--- a/tests/podcheck_regression_tests.sh
+++ b/tests/podcheck_regression_tests.sh
@@ -4,14 +4,30 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 tmp_dir="$(mktemp -d)"
 fake_bin="${tmp_dir}/bin"
+collector_dir="${tmp_dir}/collector"
 log_file="${tmp_dir}/commands.log"
-mkdir -p "$fake_bin"
+mkdir -p "$fake_bin" "$collector_dir"
 trap 'rm -rf "$tmp_dir"' EXIT
 
 cat > "${fake_bin}/curl" <<'CURL'
 #!/usr/bin/env bash
+range_end=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -r)
+      range_end="${2##*-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
 printf '%s\n' 'VERSION="v1.2.2"'
-printf '%s\n' '# ChangeNotes: regression test fixture'
+if [[ "$range_end" -ge 512 ]]; then
+  printf '%s\n' '# ChangeNotes: regression test fixture'
+fi
 CURL
 
 cat > "${fake_bin}/regctl" <<'REGCTL'
@@ -175,6 +191,18 @@ chmod +x "${fake_bin}/curl" "${fake_bin}/regctl" "${fake_bin}/jq" "${fake_bin}/p
 
 export PATH="${fake_bin}:${PATH}"
 export FAKE_PODMAN_LOG="$log_file"
+export FAKE_CONTAINERS="web db"
+
+latest_snippet="$(curl --retry 3 --retry-delay 1 --connect-timeout 5 -sf -r 0-1024 "fixture")"
+latest_changes="$(echo "${latest_snippet}" | sed -n "/ChangeNotes/s/# ChangeNotes: //p")"
+[[ "$latest_changes" == "regression test fixture" ]]
+
+: > "$log_file"
+bash "${repo_root}/podcheck.sh" -n -c "$collector_dir" web,db > "${tmp_dir}/check.log"
+grep -Fq 'name=^(web|db)$' "$log_file"
+grep -Fq 'podcheck_total 2' "${collector_dir}/podcheck.prom"
+grep -Fq 'podcheck_images_analyzed 2' "${collector_dir}/podcheck.prom"
+
 project_dir="${tmp_dir}/project with spaces"
 mkdir -p "$project_dir"
 export FAKE_PROJECT_DIR="$project_dir"

--- a/tests/podcheck_regression_tests.sh
+++ b/tests/podcheck_regression_tests.sh
@@ -24,7 +24,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-printf '%s\n' 'VERSION="v1.2.2"'
+printf '%s\n' 'VERSION="v1.2.3"'
 if [[ "$range_end" -ge 512 ]]; then
   printf '%s\n' '# ChangeNotes: regression test fixture'
 fi


### PR DESCRIPTION
This is the v1.2.3 follow-up to the compose recreation fix that landed in v1.2.2.

## Summary
- keep comma-separated container filters working through the full check/update run
- export the missing Prometheus totals and check duration without breaking the existing dashboard metrics
- return cleanly from sourced webhook notification templates
- fetch enough of the script header for self-update change notes to show reliably
- bump the script and changelog to v1.2.3 so these fixes are not grouped under v1.2.2

## Testing
- bash tests/podcheck_regression_tests.sh
- bash -n podcheck.sh notify_templates/notify_HA.sh notify_templates/notify_discord.sh notify_templates/notify_slack.sh notify_templates/notify_telegram.sh addons/prometheus/prometheus_collector.sh tests/podcheck_regression_tests.sh
- git diff --check