### PR TITLE
fix: keep update notes in header range

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ All dockcheck v0.7.1 notification services are now supported with enhanced funct
 ___
 ## Changelog
 
+- **v1.2.4**: 🐛 **Bug Fixes**
+    - **Fixed**: Keep self-update change notes visible to older updater versions.
 - **v1.2.3**: 🐛 **Bug Fixes**
     - **Fixed**: Keep comma-separated container filters working through the whole run.
     - **Fixed**: Export Prometheus totals and check duration while keeping the existing dashboard metrics.

--- a/podcheck.sh
+++ b/podcheck.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 shopt -s nullglob
 shopt -s failglob
 
-VERSION="v1.2.3"
-# ChangeNotes: Fix self-update change notes
+VERSION="v1.2.4"
+# ChangeNotes: v1.2.2 compose fix; v1.2.3 filters/metrics/webhooks; v1.2.4 update notes
 
 # Variables for self-updating
 ScriptArgs=( "$@" )

--- a/podcheck.sh
+++ b/podcheck.sh
@@ -4,13 +4,13 @@ shopt -s nullglob
 shopt -s failglob
 
 VERSION="v1.2.3"
+# ChangeNotes: Fix self-update change notes
 
 # Variables for self-updating
 ScriptArgs=( "$@" )
 ScriptPath="$(readlink -f "$0")"
 ScriptWorkDir="$(dirname "$ScriptPath")"
 
-# ChangeNotes: Fix filters, Prometheus metrics, webhook returns, and self-update notes
 Github="https://github.com/sudo-kraken/podcheck"
 RawUrl="https://raw.githubusercontent.com/sudo-kraken/podcheck/main/podcheck.sh"
 

--- a/tests/podcheck_regression_tests.sh
+++ b/tests/podcheck_regression_tests.sh
@@ -24,7 +24,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-printf '%s\n' 'VERSION="v1.2.3"'
+printf '%s\n' 'VERSION="v1.2.4"'
 if [[ "$range_end" -ge 200 ]]; then
   printf '%s\n' '# ChangeNotes: regression test fixture'
 fi
@@ -194,7 +194,7 @@ export FAKE_PODMAN_LOG="$log_file"
 export FAKE_CONTAINERS="web db"
 
 header_changes="$(head -c 200 "${repo_root}/podcheck.sh" | sed -n "/ChangeNotes/s/# ChangeNotes: //p")"
-[[ "$header_changes" == "Fix self-update change notes" ]]
+[[ "$header_changes" == "v1.2.2 compose fix; v1.2.3 filters/metrics/webhooks; v1.2.4 update notes" ]]
 
 latest_snippet="$(curl --retry 3 --retry-delay 1 --connect-timeout 5 -sf -r 0-1024 "fixture")"
 latest_changes="$(echo "${latest_snippet}" | sed -n "/ChangeNotes/s/# ChangeNotes: //p")"

--- a/tests/podcheck_regression_tests.sh
+++ b/tests/podcheck_regression_tests.sh
@@ -25,7 +25,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 printf '%s\n' 'VERSION="v1.2.3"'
-if [[ "$range_end" -ge 512 ]]; then
+if [[ "$range_end" -ge 200 ]]; then
   printf '%s\n' '# ChangeNotes: regression test fixture'
 fi
 CURL
@@ -192,6 +192,9 @@ chmod +x "${fake_bin}/curl" "${fake_bin}/regctl" "${fake_bin}/jq" "${fake_bin}/p
 export PATH="${fake_bin}:${PATH}"
 export FAKE_PODMAN_LOG="$log_file"
 export FAKE_CONTAINERS="web db"
+
+header_changes="$(head -c 200 "${repo_root}/podcheck.sh" | sed -n "/ChangeNotes/s/# ChangeNotes: //p")"
+[[ "$header_changes" == "Fix self-update change notes" ]]
 
 latest_snippet="$(curl --retry 3 --retry-delay 1 --connect-timeout 5 -sf -r 0-1024 "fixture")"
 latest_changes="$(echo "${latest_snippet}" | sed -n "/ChangeNotes/s/# ChangeNotes: //p")"


### PR DESCRIPTION
The v1.2.3 updater fixed the byte range for future releases, but older versions still only read the first 200 bytes of `podcheck.sh`. In v1.2.3 the `ChangeNotes` line started after that, so the v1.2.2 -> v1.2.3 prompt still showed an empty notes field.

## Summary
- move `ChangeNotes` directly under `VERSION` so older updaters can parse it
- show a compact cumulative note for v1.2.2, v1.2.3, and v1.2.4 in the update prompt
- add a regression check for the first 200 bytes of the script header
- bump the patch version to v1.2.4

## Testing
- bash tests/podcheck_regression_tests.sh
- bash -n podcheck.sh notify_templates/notify_HA.sh notify_templates/notify_discord.sh notify_templates/notify_slack.sh notify_templates/notify_telegram.sh addons/prometheus/prometheus_collector.sh tests/podcheck_regression_tests.sh
- git diff --check -- podcheck.sh tests/podcheck_regression_tests.sh